### PR TITLE
update zeroshot prompt format to 4.0

### DIFF
--- a/bothub/api/v2/zeroshot/usecases/format_prompt.py
+++ b/bothub/api/v2/zeroshot/usecases/format_prompt.py
@@ -1,34 +1,32 @@
-BASE_PROMPT = """<s>[INST] {context_description} {context}
+BASE_PROMPT = """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
+
+{context_description} {context}
 {reflection}
 
 # {classes_title}
-{all_classes}
+{all_classes}<|eot_id|><|start_header_id|>user<|end_header_id|>
 
-# {sentence_title} {input}
-# {class_id_title} [/INST]"""
+{input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
+
+
+"""
 
 class FormatPrompt:
     const_prompt_data = {
         "por": {
             "context_description": "Você é muito especialista em classificar a frase do usuário em um chatbot sobre:",
             "reflection": "Pare, pense bem e responda com APENAS UM ÚNICO `id` da classe que melhor represente a intenção para a frase do usuário de acordo com a análise de seu contexto, responda APENAS com o `id` da classe só se você tiver muita certeza e não explique o motivo. Na ausência, falta de informações ou caso a frase do usuário não se enquadre em nenhuma classe, classifique como \"-1\".",
-            "classes_title": "Essas são as Classes com seus Id e Contexto:",
-            "sentence_title": "Frase do usuário:",
-            "class_id_title": "Id da Classe:"
+            "classes_title": "Essas são as Classes com seus Id e Contexto:"
         }, 
         "eng": {
             "context_description": "You are very expert in classifying the user sentence in a chatbot about:",
             "reflection": "Stop, think carefully, and respond with ONLY ONE SINGLE `id` of the class that best represents the intention for the user's sentence according to the analysis of its context, respond ONLY with the `id` of the class if you are very sure and do not explain the reason. In the absence, lack of information, or if the user's sentence does not fit into any class, classify as \"-1\".",
-            "classes_title": "These are the Classes and its Context:",
-            "sentence_title": "User's sentence:",
-            "class_id_title": "Class Id:"
+            "classes_title": "These are the Classes and its Context:"
         },
         "spa": {
             "context_description": "Eres muy experto en clasificar la frase del usuario en un chatbot sobre:",
             "reflection": "Deténgase, piense bien y responda con SOLO UN ÚNICO `id` de la clase que mejor represente la intención para la frase del usuario de acuerdo con el análisis de su contexto, responda SOLO con el `id` de la clase si está muy seguro y no explique el motivo. En ausencia, falta de información o en caso de que la frase del usuario no se ajuste a ninguna clase, clasifique como \"-1\".",
-            "classes_title": "Estas son las Clases con sus Id y Contexto:",
-            "sentence_title": "Frase del usuario:",
-            "class_id_title": "Id de la Clase:"
+            "classes_title": "Estas son las Clases con sus Id y Contexto:"
         }
     }
 
@@ -41,11 +39,10 @@ class FormatPrompt:
         prompt = BASE_PROMPT.format(context_description=translated_text.get("context_description"),
                                     reflection=translated_text.get("reflection"),
                                     classes_title=translated_text.get("classes_title"),
-                                    sentence_title=translated_text.get("sentence_title"),
-                                    class_id_title=translated_text.get("class_id_title"),
                                     context=context,
                                     all_classes=all_classes,
                                     input=input)
+        print(f"prompt: {prompt}")
 
         return prompt
     

--- a/bothub/api/v2/zeroshot/usecases/format_prompt.py
+++ b/bothub/api/v2/zeroshot/usecases/format_prompt.py
@@ -8,7 +8,6 @@ BASE_PROMPT = """<|begin_of_text|><|start_header_id|>system<|end_header_id|>
 
 {input}<|eot_id|><|start_header_id|>assistant<|end_header_id|>
 
-
 """
 
 class FormatPrompt:


### PR DESCRIPTION
# Description
Updating the zeroshot prompt to version `4.0.23`. The modified file was '`format_prompt.py`' with the inclusion of this version's prompt. The base prompt now contains tokens of `chat template` and the model is on the `llama3` architecture.

---


Portuguese
```
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

Você é muito especialista em classificar a frase do usuário em um chatbot sobre: Atendimento ao cliente da Samsung, com foco em tirar dúvidas sobre o processo de compra, devolução e políticas, mas também vendendo produtos de eletro.
Pare, pense bem e responda com APENAS UM ÚNICO `id` da classe que melhor represente a intenção para a frase do usuário de acordo com a análise de seu contexto, responda APENAS com o `id` da classe só se você tiver muita certeza e não explique o motivo. Na ausência, falta de informações ou caso a frase do usuário não se enquadre em nenhuma classe, classifique como "-1".

# Essas são as Classes com seus Id e Contexto:
[{'class': 'Compra', 'context': 'Quando o usuário quiser buscar novos produtos', 'id': 1}, {'class': 'Pesquisar produtos', 'context': 'Quando o usuário estiver procurando por produtos da Samsung para compra', 'id': 2}, {'class': 'Status Pedidos', 'context': 'Quando o usuário estiver consultando o status de um pedido específico, se foi entregue ou cancelado, por exemplo', 'id': 3}]<|eot_id|><|start_header_id|>user<|end_header_id|>

tem galaxy?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
```

English
```
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

You are very expert in classifying the user sentence in a chatbot about: Samsung customer service, focusing on answering questions about the purchase process, returns and policies, but also selling electrical products.
Stop, think carefully, and respond with ONLY ONE SINGLE `id` of the class that best represents the intention for the user's sentence according to the analysis of its context, respond ONLY with the `id` of the class if you are very sure and do not explain the reason. In the absence, lack of information, or if the user's sentence does not fit into any class, classify as "-1".

# These are the Classes and its Context:
[{'class': 'Purchase', 'context': 'When the user wants to search for new products', 'id': 1}, {'class': 'Search products', 'context': 'When the user is searching for Samsung products to purchase', 'id': 2}, {'class': 'Order Status', 'context': 'When the user is checking the status of a specific order, whether it has been delivered or cancelled, for example', 'id': 3}]<|eot_id|><|start_header_id|>user<|end_header_id|>

do you have a galaxy?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
```


Spanish
```
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

Eres muy experto en clasificar la frase del usuario en un chatbot sobre: tención al cliente de Samsung, enfocándose en resolver dudas sobre el proceso de compra, devoluciones y políticas, pero también en la venta de productos eléctricos
Deténgase, piense bien y responda con SOLO UN ÚNICO `id` de la clase que mejor represente la intención para la frase del usuario de acuerdo con el análisis de su contexto, responda SOLO con el `id` de la clase si está muy seguro y no explique el motivo. En ausencia, falta de información o en caso de que la frase del usuario no se ajuste a ninguna clase, clasifique como "-1".

# Estas son las Clases con sus Id y Contexto:
[{'class': 'Buscar productos', 'context': 'Cuando el usuario busca productos Samsung para comprar', 'id': 1}, {'class': 'Search products', 'context': 'When the user is searching for Samsung products to purchase', 'id': 2}, {'class': 'Estado del pedido', 'context': 'Cuandoelusuarioestácomprobandoelestadodeunpedidoespecífico', 'id': 3}]<|eot_id|><|start_header_id|>user<|end_header_id|>

¿tienes una galaxia?<|eot_id|><|start_header_id|>assistant<|end_header_id|>
```
